### PR TITLE
Typos 3.7

### DIFF
--- a/modules/ROOT/pages/adding-query-pagination-support.adoc
+++ b/modules/ROOT/pages/adding-query-pagination-support.adoc
@@ -53,7 +53,7 @@ public abstract class ProviderAwarePagingDelegate<T, P> implements Closeable
      * no more items are available
      *
      * @param provider The provider to be used to do the query.
-     * You can assume this provider is already properly initialised
+     * You can assume this provider is already properly initialized
      * @return a populated list of elements. <code>null</code>
      * or an empty list, then it means no more items are available
      * @throws Exception
@@ -67,7 +67,7 @@ public abstract class ProviderAwarePagingDelegate<T, P> implements Closeable
      * returned in such a case.
      *
      * @param provider The provider to be used to do the query.
-     * You can assume this provider is already properly initialised.
+     * You can assume this provider is already properly initialized.
      */
     public abstract int getTotalResults(P provider) throws Exception;
 

--- a/modules/ROOT/pages/annotation-reference.adoc
+++ b/modules/ROOT/pages/annotation-reference.adoc
@@ -2241,7 +2241,7 @@ You can use the <<rsupan,@RestUriParam>>  annotation, as well as other related a
 
 When generating the request call, DevKit includes a non-annotated argument and an argument annotated with <<payan,@Payload>> as the body of the call.
 
-When applying annotations to @Processor methods, specify a placeholder in the URI by surrounding the placeholder with curly braces, for example  ` {type}. `
+When applying annotations to @Processor methods, specify a placeholder in the URI by surrounding the placeholder with curly braces, for example  ` \{type}. `
 
 You can apply @RestUriParam to @Processor methods arguments as follows:
 

--- a/modules/ROOT/pages/annotation-reference.adoc
+++ b/modules/ROOT/pages/annotation-reference.adoc
@@ -1100,7 +1100,7 @@ public void initialize() {
 }
 ----
 
-*Note:* `iniitalise` is a reserved word that cannot be used as the method's name.
+*Note:* `initialise` is a reserved word that cannot be used as the method's name.
 
 See also: <<displ,@Dispose>>   <<stan,@Start>>   <<stopan,@Stop>>
 
@@ -2458,7 +2458,7 @@ public void connect(@ConnectionKey String username, @Password String password,
     ServiceClient client = new ServiceClient(username, password);
     try {
         client.connect(url, optionalConnectionParams);
-    } catch (SerivceConnectionException e) {
+    } catch (ServiceConnectionException e) {
         throw new ConnectionException(getExceptionCode(e.getCause()), e.getCode(), e.getMessage(), e);
     }
 }
@@ -2510,7 +2510,7 @@ public class BasicConnectionStrategy{
       throw new ConnectionException(
          ConnectionExceptionCode.CANNOT_REACH,
          "what your API has returned, if it did..",
-         "some meaninful stuff about your API")
+         "some meaningful stuff about your API")
     }
     ...
     //if we manage to get here, it means that the connection was

--- a/modules/ROOT/pages/creating-a-connector-for-a-soap-service-via-cxf-client.adoc
+++ b/modules/ROOT/pages/creating-a-connector-for-a-soap-service-via-cxf-client.adoc
@@ -49,7 +49,7 @@ image::image2013-8-11-173a213a7.png[image2013-8-11+173A213A7]
 
 == Example Service: SunSetRiseService
 
-Example files are available in the attached link:{attachmentsdir}/CxfExampleFiles.zip[CxfExampleFiies.zip] file for the sections of this document that follow.
+Example files are available in the attached link:{attachmentsdir}/CxfExampleFiles.zip[CxfExampleFiles.zip] file for the sections of this document that follow.
 
 The request and response are both represented by an XML document that specifies:
 
@@ -878,7 +878,7 @@ Once you get through the process above, you have a working SOAP CXF connector. Y
 
 * Add more operations using the same process
 * Check out some of the other xref:anypoint-connector-examples.adoc[examples]
-* Example files are available in the attached link:{attachmentsdir}/CxfExampleFiles.zip[CxfExampleFiies.zip] file for the WSDL2Java sections of this document
+* Example files are available in the attached link:{attachmentsdir}/CxfExampleFiles.zip[CxfExampleFiles.zip] file for the WSDL2Java sections of this document
 
 == Appendix - sunsetriseservice WSDL
 

--- a/modules/ROOT/pages/creating-a-soap-connector.adoc
+++ b/modules/ROOT/pages/creating-a-soap-connector.adoc
@@ -273,7 +273,7 @@ public abstract class AbstractTShirtWSDLProvider {
 }
 ----
 +
-. Code a first provider implementation of the abstract class, for example, for women's Tshirts:
+. Code a first provider implementation of the abstract class, for example, for women's T-shirts:
 +
 [source,java,linenums]
 ----
@@ -288,7 +288,7 @@ public class TShirtWSDLProvider extends AbstractTShirtWSDLProvider {
 }
 ----
 +
-. Code the next provider implementation of the abstract class, in this case, for men's Tshirts:
+. Code the next provider implementation of the abstract class, in this case, for men's T-shirts:
 +
 [source,java,linenums]
 ----
@@ -307,7 +307,7 @@ Both steps 3 and 4 generate two global elements, one for each type of configurat
 
 === Multiple Level DataSense for WSDL Provider
 
-When implementing a WSDL-based connector using a @WsdProvider, the developer provides one or many service definitions retrieved from one or many WSLDProvider strategies. For each of this ServiceDefinitions, the connector presents multiple operations.
+When implementing a WSDL-based connector using a @WsdlProvider, the developer provides one or many service definitions retrieved from one or many WSDLProvider strategies. For each of this ServiceDefinitions, the connector presents multiple operations.
 
 Using this connector, then, implies that the user selects a Service and an Operation to be invoked.
 
@@ -399,15 +399,15 @@ public ServiceDefinition getDefinitions() {
 }
 ----
 
-==== Multiple WSLDProviders Restriction
+==== Multiple WSDLProviders Restriction
 
 When declaring multiple WSDLProvider strategies, all must be consistent in the ServiceDefinitionRetriever declaration.
 
 This includes:
 
 * Return type must be the same for all the strategies, that is either all return List<ServiceDefinition> or all return ServiceDefinition.
-* If overrided labels must be the same for all the retrievers.
-* If overrided keySeparator must be the same for all the retrievers.
+* If overridden, labels must be the same for all the retrievers.
+* If overridden, keySeparator must be the same for all the retrievers.
 
 ==== Separator and Labels Restrictions
 
@@ -570,7 +570,7 @@ public class TShirtWSDLProvider {
 }
 ----
 
-The key part about this strategies, within @WsdlSecurity, is that a connector developer must rely on the @Configurables already in place. This means that if it want to use username token profile, then it must have a way to parametrize the connector with username, password, etc. Once the concrete instances of @WsdlSecurityStrategy initialize, DevKit takes care of the rest, parametrizing each to the underlying engine in the Web Service Consumer.
+The key part about this strategies, within @WsdlSecurity, is that a connector developer must rely on the @Configurables already in place. This means that if it want to use username token profile, then it must have a way to parametrize the connector with username, password, etc. Once the concrete instances of @WsdlSecurityStrategy initialize, DevKit takes care of the rest, parameterizing each to the underlying engine in the Web Service Consumer.
 
 === Transport Authentication with HTTP Basic Authentication
 

--- a/modules/ROOT/pages/creating-a-soap-connector.adoc
+++ b/modules/ROOT/pages/creating-a-soap-connector.adoc
@@ -570,7 +570,7 @@ public class TShirtWSDLProvider {
 }
 ----
 
-The key part about this strategies, within @WsdlSecurity, is that a connector developer must rely on the @Configurables already in place. This means that if it want to use username token profile, then it must have a way to parametrize the connector with username, password, etc. Once the concrete instances of @WsdlSecurityStrategy initialize, DevKit takes care of the rest, parameterizing each to the underlying engine in the Web Service Consumer.
+The key part about this strategies, within @WsdlSecurity, is that a connector developer must rely on the @Configurables already in place. To use the username token profile, there must be a way to parametrize the connector with a username, a password, and so on. Once the concrete instances of @WsdlSecurityStrategy initialize, DevKit takes care of the rest, parameterizing each to the underlying engine in the Web Service Consumer.
 
 === Transport Authentication with HTTP Basic Authentication
 

--- a/modules/ROOT/pages/creating-a-soap-connector.adoc
+++ b/modules/ROOT/pages/creating-a-soap-connector.adoc
@@ -407,7 +407,7 @@ This includes:
 
 * Return type must be the same for all the strategies, that is either all return List<ServiceDefinition> or all return ServiceDefinition.
 * If overridden, labels must be the same for all the retrievers.
-* If overridden, keySeparator must be the same for all the retrievers.
+* If overridden, the keySeparator must be the same for all the retrievers.
 
 ==== Separator and Labels Restrictions
 

--- a/modules/ROOT/pages/no-authentication.adoc
+++ b/modules/ROOT/pages/no-authentication.adoc
@@ -6,7 +6,7 @@ endif::[]
 
 include::partial$devkit-important.adoc[]
 
-When a connector does not use authentiation, you can use `@Connector` with `@Configuration`.
+When a connector does not use authentication, you can use `@Connector` with `@Configuration`.
 
 `@Configuration` adds a set of `@Configurable` fields to your connector as a connector configuration.
 

--- a/modules/ROOT/pages/shading-libraries.adoc
+++ b/modules/ROOT/pages/shading-libraries.adoc
@@ -48,7 +48,7 @@ The following example shows the use of the plugin for shading artifacts:
        <relocations>
          <relocation>
             <pattern>org.some.library</pattern>
-            <shadedPattern>org.some.library.new.pakage.name.shade</shadedPattern>
+            <shadedPattern>org.some.library.new.package.name.shade</shadedPattern>
          </relocation>
        </relocations>
       </configuration>


### PR DESCRIPTION
- fix typos
- escape one of the curly brackets so it doesn't generate a warning