### PR TITLE
Typos 3.8

### DIFF
--- a/modules/ROOT/pages/adding-query-pagination-support.adoc
+++ b/modules/ROOT/pages/adding-query-pagination-support.adoc
@@ -53,7 +53,7 @@ public abstract class ProviderAwarePagingDelegate<T, P> implements Closeable
      * no more items are available
      *
      * @param provider The provider to be used to do the query.
-     * You can assume this provider is already properly initialised
+     * You can assume this provider is already properly initialized
      * @return a populated list of elements. <code>null</code>
      * or an empty list, then it means no more items are available
      * @throws Exception
@@ -67,7 +67,7 @@ public abstract class ProviderAwarePagingDelegate<T, P> implements Closeable
      * returned in such a case.
      *
      * @param provider The provider to be used to do the query.
-     * You can assume this provider is already properly initialised.
+     * You can assume this provider is already properly initialized.
      */
     public abstract int getTotalResults(P provider) throws Exception;
 

--- a/modules/ROOT/pages/creating-a-connector-for-a-soap-service-via-cxf-client.adoc
+++ b/modules/ROOT/pages/creating-a-connector-for-a-soap-service-via-cxf-client.adoc
@@ -52,7 +52,7 @@ image::image2013-8-11-173a213a7.png[image2013-8-11+173A213A7]
 The web service for the demo is the SunSetRise Web service. The <<Appendix - sunsetriseservice WSDL>> provides access information.
 
 [TIP]
-Example files are available in the attached link:{attachmentsdir}/CxfExampleFiles.zip[CxfExampleFiies.zip] file for the sections of this document that follow.
+Example files are available in the attached link:{attachmentsdir}/CxfExampleFiles.zip[CxfExampleFiles.zip] file for the sections of this document that follow.
 
 
 The request and response are both represented by an XML document that specifies:
@@ -882,7 +882,7 @@ http://www.mulesoft.org/schema/mule/json http://www.mulesoft.org/schema/mule/jso
 Once you get through the process above, you have a working SOAP CXF connector. You can:
 
 * Add more operations using the same process
-* Example files are available in the attached link:{attachmentsdir}/CxfExampleFiles.zip[CxfExampleFiies.zip] file for the WSDL2Java sections of this document
+* Example files are available in the attached link:{attachmentsdir}/CxfExampleFiles.zip[CxfExampleFiles.zip] file for the WSDL2Java sections of this document
 
 == Appendix - sunsetriseservice WSDL
 

--- a/modules/ROOT/pages/creating-a-soap-connector.adoc
+++ b/modules/ROOT/pages/creating-a-soap-connector.adoc
@@ -435,7 +435,7 @@ This includes:
 
 * Return type must be the same for all the strategies, that is either all return List<ServiceDefinition> or all return ServiceDefinition.
 * If overridden, labels must be the same for all the retrievers.
-* If overridden, keySeparator must be the same for all the retrievers.
+* If overridden, the keySeparator must be the same for all the retrievers.
 
 ==== Separator and Labels Restrictions
 

--- a/modules/ROOT/pages/creating-a-soap-connector.adoc
+++ b/modules/ROOT/pages/creating-a-soap-connector.adoc
@@ -598,7 +598,7 @@ public class TShirtWSDLProvider {
 }
 ----
 
-The key part about this strategies, within @WsdlSecurity, is that a connector developer must rely on the @Configurables already in place. This means that if it want to use username token profile, then it must have a way to parametrize the connector with username, password, etc. Once the concrete instances of @WsdlSecurityStrategy initialize, DevKit takes care of the rest, parameterizing each to the underlying engine in the Web Service Consumer.
+The key part about this strategies, within @WsdlSecurity, is that a connector developer must rely on the @Configurables already in place. To use the username token profile, there must be a way to parametrize the connector with a username, a password, and so on. Once the concrete instances of @WsdlSecurityStrategy initialize, DevKit takes care of the rest, parameterizing each to the underlying engine in the Web Service Consumer.
 
 === Transport Authentication with HTTP Basic Authentication
 

--- a/modules/ROOT/pages/creating-a-soap-connector.adoc
+++ b/modules/ROOT/pages/creating-a-soap-connector.adoc
@@ -301,7 +301,7 @@ public abstract class AbstractTShirtWSDLProvider {
 }
 ----
 +
-. Code a first provider implementation of the abstract class, for example, for women's Tshirts:
+. Code a first provider implementation of the abstract class, for example, for women's T-shirts:
 +
 [source,java,linenums]
 ----
@@ -316,7 +316,7 @@ public class TShirtWSDLProvider extends AbstractTShirtWSDLProvider {
 }
 ----
 +
-. Code the next provider implementation of the abstract class, in this case, for men's Tshirts:
+. Code the next provider implementation of the abstract class, in this case, for men's T-shirts:
 +
 [source,java,linenums]
 ----
@@ -335,7 +335,7 @@ Both steps 3 and 4 generate two global elements, one for each type of configurat
 
 === Multiple Level DataSense for WSDL Provider
 
-When implementing a WSDL-based connector using a @WsdProvider, the developer provides one or many service definitions retrieved from one or many WSLDProvider strategies. For each of this ServiceDefinitions, the connector presents multiple operations.
+When implementing a WSDL-based connector using a @WsdlProvider, the developer provides one or many service definitions retrieved from one or many WSDLProvider strategies. For each of this ServiceDefinitions, the connector presents multiple operations.
 
 Using this connector, then, implies that the user selects a Service and an Operation to be invoked.
 
@@ -427,15 +427,15 @@ public ServiceDefinition getDefinitions() {
 }
 ----
 
-==== Multiple WSLDProviders Restriction
+==== Multiple WSDLProviders Restriction
 
 When declaring multiple WSDLProvider strategies, all must be consistent in the ServiceDefinitionRetriever declaration.
 
 This includes:
 
 * Return type must be the same for all the strategies, that is either all return List<ServiceDefinition> or all return ServiceDefinition.
-* If overrided labels must be the same for all the retrievers.
-* If overrided keySeparator must be the same for all the retrievers.
+* If overridden, labels must be the same for all the retrievers.
+* If overridden, keySeparator must be the same for all the retrievers.
 
 ==== Separator and Labels Restrictions
 
@@ -598,7 +598,7 @@ public class TShirtWSDLProvider {
 }
 ----
 
-The key part about this strategies, within @WsdlSecurity, is that a connector developer must rely on the @Configurables already in place. This means that if it want to use username token profile, then it must have a way to parametrize the connector with username, password, etc. Once the concrete instances of @WsdlSecurityStrategy initialize, DevKit takes care of the rest, parametrizing each to the underlying engine in the Web Service Consumer.
+The key part about this strategies, within @WsdlSecurity, is that a connector developer must rely on the @Configurables already in place. This means that if it want to use username token profile, then it must have a way to parametrize the connector with username, password, etc. Once the concrete instances of @WsdlSecurityStrategy initialize, DevKit takes care of the rest, parameterizing each to the underlying engine in the Web Service Consumer.
 
 === Transport Authentication with HTTP Basic Authentication
 

--- a/modules/ROOT/pages/defining-message-sources.adoc
+++ b/modules/ROOT/pages/defining-message-sources.adoc
@@ -113,7 +113,7 @@ callback.process("testMessage", properties);
 }
 ----
 
-After this is built into a connector, it contains an inbound property called originalFiname with value `123.txt` after the message source.
+After this is built into a connector, it contains an inbound property called originalFilename with value `123.txt` after the message source.
 
 == See Also
 

--- a/modules/ROOT/pages/devkit-tutorial.adoc
+++ b/modules/ROOT/pages/devkit-tutorial.adoc
@@ -614,7 +614,7 @@ In this tutorial, we use a static DataSense model, which means that the entities
 
 To use DataSense in the cookbook:
 
-. Analyze the entities in {mule} service. We only have two simple entities, Recipe and Ingredient that both extend from CookBookEntity.
+. Analyze the entities in \{mule} service. We only have two simple entities, Recipe and Ingredient that both extend from CookBookEntity.
 . Look at how our createIngredient operation looks inside Anypoint Studio, and how it interacts with other components.
 +
 [source,java,linenums]
@@ -721,7 +721,7 @@ include::{examplesdir}/java/v5/CookbookConnector.java[lines=115..121]
 +
 image::datasense-static.png[width="800"]
 +
-Now even the {dataWeave} knows how to interact with our @Connector:
+Now even the \{dataWeave} knows how to interact with our @Connector:
 +
 image::datasense-static2.png[width="800"]
 

--- a/modules/ROOT/pages/devkit-tutorial.adoc
+++ b/modules/ROOT/pages/devkit-tutorial.adoc
@@ -1072,9 +1072,9 @@ See:
 
 * xref:authentication.adoc[Authentication] documentation.
 * xref:oauth-v2.adoc[OAuth V2].
-* <<mutiple-connection-strategies,Supporting Multiple Connection Strategies>>.
+* <<multiple-connection-strategies,Supporting Multiple Connection Strategies>>.
 
-[[mutiple-connection-strategies]]
+[[multiple-connection-strategies]]
 
 == Multiple Configurations
 

--- a/modules/ROOT/pages/no-authentication.adoc
+++ b/modules/ROOT/pages/no-authentication.adoc
@@ -6,7 +6,7 @@ endif::[]
 
 include::partial$devkit-important.adoc[]
 
-When a connector does not use authentiation, you can use `@Connector` with `@Configuration`.
+When a connector does not use authentication, you can use `@Connector` with `@Configuration`.
 
 `@Configuration` adds a set of `@Configurable` fields to your connector as a connector configuration.
 

--- a/modules/ROOT/pages/setting-up-your-dev-environment.adoc
+++ b/modules/ROOT/pages/setting-up-your-dev-environment.adoc
@@ -44,7 +44,7 @@ Anypoint Studio must be configured to reference the location of your JDK rather 
 
 image::installed-jres-jdk.png[installed jres]
 
-NOTE: When referencing the root of your JRE instead of a JDK, Maven will be unable to resolve the DevKit-required depenency `com.sun:tools:jar:1.6`. An error describing the inability to resolve this dependency will show up in the console when the build process kicks off.
+NOTE: When referencing the root of your JRE instead of a JDK, Maven will be unable to resolve the DevKit-required dependency `com.sun:tools:jar:1.6`. An error describing the inability to resolve this dependency will show up in the console when the build process kicks off.
 
 == Apache Maven
 


### PR DESCRIPTION
- fix typos
- escape brackets properly to remove build warning